### PR TITLE
Add hint to help find the relevant part of the Node docs

### DIFF
--- a/problems/hexadecimal_encoding/problem.txt
+++ b/problems/hexadecimal_encoding/problem.txt
@@ -29,8 +29,8 @@ a correct solution, run `{bold}{appname}{/bold}` again and select the next probl
 
 ----------------------------------------------------------------------
 HINTS:
-
-.toString
+- 'bytes' are also referred to as 'octets' in the node documentation linked below
+- .toString
 
 Read more about Buffers here:
   http://nodejs.org/api/all.html#all_buffer


### PR DESCRIPTION
When I approached this problem I was pretty confused about what was being asked for or perhaps more specifically how to get the string provided (`0 15 24 3 250 83`) into a buffer.  Enter it as a string? Enter with string & use encoding hex?  Use an array? Enter as an array with encoding hex?

I searched the linked docs page for "byte" but that didn't help much- the [constructor that took an Array](http://nodejs.org/api/all.html#all_new_buffer_array) did not mention "bytes."  Thru trial and error I figured out that 1. the string should be entered as an array 2. conversion to hex isn't worried about until output & 3. **bytes & octets are interchangeable in that part of the docs.**  I think adding a hint for point 3 is justifiable.
