### PR TITLE
Updated a couple of solutions to use newer ways to instantiate node buffers

### DIFF
--- a/exercises/buffer_from_string/solution/solution.js
+++ b/exercises/buffer_from_string/solution/solution.js
@@ -1,1 +1,1 @@
-console.log(new Buffer('bytewiser'))
+console.log(Buffer.from('bytewiser'))

--- a/exercises/hexadecimal_encoding/solution/solution.js
+++ b/exercises/hexadecimal_encoding/solution/solution.js
@@ -1,2 +1,2 @@
-var bytes = process.argv.slice(2).map(Number)
-console.log(new Buffer(bytes).toString('hex'))
+let bytes = Buffer.from(process.argv.slice(2).map(Number));
+console.log(buff.toString('hex'));

--- a/exercises/hexadecimal_encoding/solution/solution.js
+++ b/exercises/hexadecimal_encoding/solution/solution.js
@@ -1,2 +1,2 @@
 var bytes = process.argv.slice(2).map(Number)
-console.log(new Buffer(bytes).toString('hex'))
+console.log(Buffer.from(bytes).toString('hex'))


### PR DESCRIPTION
Changed the solutions to a couple of the exercises to use the non-deprecated way to create node buffers. It is kind of confusing because you do still use like 
    
    const arr = new Uint16Array(20);

In a browser but in the node docs say to use Buffer.from(stufftomakebuffer) or Buffer.alloc(size) to make new buffers.  Though using new Buffer should work for the for a while yet. Maybe both kinds of solutions should be shown because new Buffer() is used a lot? 

see: https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_buffer