### PR TITLE
Update to Buffer.from

### DIFF
--- a/exercises/buffer_from_string/problem.md
+++ b/exercises/buffer_from_string/problem.md
@@ -11,7 +11,7 @@ the string `"bytewiser"` using `console.log`.
 
 Read more about Buffers here:
 
-  http://nodejs.org/api/all.html#all_buffer
+  `http://nodejs.org/api/all.html#all_buffer`
 
 Or off-line on your local filesystem:
 

--- a/exercises/buffer_from_string/solution/solution.js
+++ b/exercises/buffer_from_string/solution/solution.js
@@ -1,1 +1,1 @@
-console.log(new Buffer('bytewiser'))
+console.log(Buffer.from('bytewiser'))

--- a/exercises/hexadecimal_encoding/solution/solution.js
+++ b/exercises/hexadecimal_encoding/solution/solution.js
@@ -1,2 +1,2 @@
 var bytes = process.argv.slice(2).map(Number)
-console.log(new Buffer(bytes).toString('hex'))
+console.log(Buffer.from(bytes).toString('hex'))


### PR DESCRIPTION
`new Buffer` has been deprecated so submitting a pull request to update it to the new buffer.from.

Also updating the link as the parser didn't show it in the terminal 
![image](https://user-images.githubusercontent.com/1126497/46495304-5c1be300-c815-11e8-9544-6fe05270b202.png)
